### PR TITLE
Adding `__version__` to package

### DIFF
--- a/chalk/__init__.py
+++ b/chalk/__init__.py
@@ -17,6 +17,16 @@ from chalk.shape import (
 from chalk.point import Point, Vector
 from chalk.trail import Trail
 
+try:
+    from importlib import metadata
+except ImportError:  # for Python<3.8
+    import importlib_metadata as metadata
+
+
+__title__ = __name__
+__version__ = metadata.version(__title__)  # type: ignore
+
+
 ignore = [Trail, Vector]
 
 


### PR DESCRIPTION
- This will allow accessing the version with `chalk.__version__`.
- The version only needs maintaining inside `setup.py`